### PR TITLE
"Add Spanish and Catalan Documentation with README Instructions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 GroupLang-secretary-bot is a Telegram bot that transcribes voice messages, summarizes the content, and allows users to tip for the service. It uses AWS services for transcription and a custom API for summarization. The bot is designed to be deployed as an AWS Lambda function.
 
+## Documentation in Other Languages
+
+- [Español (Spanish)](README_es.md)
+- [Català (Catalan)](README_ca.md)
+
 ## Table of Contents
 
 - [Features](#features)


### PR DESCRIPTION
## Pull Request Description
This pull request addresses the issue #X: "Add documentation in Spanish in Catalan" in the `grouplang-secretary-bot` repository.

### Changes Made
- Added documentation in both Spanish and Catalan languages using the files provided.
- Updated the README with instructions on how to access the newly added documentation.

### Proposed Solution
To address the issue, the documentation was created in two additional languages to make it more accessible to a wider audience. The README now includes clear guidance on navigating and accessing the new documentation.

### How to Test
1. Cloned this repository to your local machine.
2. In the project directory, navigate to the updated README file.
3. Follow the instructions outlined in the README to access the documentation in Spanish and Catalan.

### Additional Notes
- Please review the changes made and ensure that the documentation is accurate and easily understandable in both languages.
- Any feedback or suggestions for improvement are highly appreciated.

This pull request aims to enhance the accessibility and reach of the documentation by providing it in Spanish and Catalan languages.