### PR TITLE
Title: Add Documentation in Spanish and Catalan with README Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ GroupLang-secretary-bot is a Telegram bot that transcribes voice messages, summa
 
 ## Table of Contents
 
+- [Documentation in Other Languages](#documentation-in-other-languages)
+
 - [Features](#features)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
@@ -12,7 +14,10 @@ GroupLang-secretary-bot is a Telegram bot that transcribes voice messages, summa
 - [Deployment](#deployment)
 - [API Reference](#api-reference)
 
-## Features
+## Documentation in Other Languages
+
+- [Español (Spanish)](README_es.md)
+- [Català (Catalan)](README_ca.md)
 
 - Transcribe voice messages using AWS Transcribe
 - Summarize transcribed text using a custom API

--- a/README_ca.md
+++ b/README_ca.md
@@ -1,0 +1,103 @@
+# GroupLang-secretary-bot
+
+GroupLang-secretary-bot és un bot de Telegram que transcriu missatges de veu, resumeix el contingut i permet als usuaris donar propines pel servei. Utilitza serveis d'AWS per a la transcripció i una API personalitzada per a resumir. El bot està dissenyat per ser desplegat com una funció d'AWS Lambda.
+
+## Taula de Continguts
+
+- [Característiques](#característiques)
+- [Requisits Previs](#requisits-previs)
+- [Instal·lació](#instal·lació)
+- [Configuració](#configuració)
+- [Ús](#ús)
+- [Desplegament](#desplegament)
+- [Referència de l'API](#referència-de-lapi)
+
+## Característiques
+
+- Transcriure missatges de veu utilitzant AWS Transcribe
+- Resumir text transcrit utilitzant una API personalitzada
+- Permetre als usuaris donar propines pel servei
+- Gestió segura de claus API i tokens
+- Desplegable com una funció d'AWS Lambda
+
+## Requisits Previs
+
+- Poetry per a la gestió de dependències
+- Compte d'AWS amb accés a Transcribe
+- Token de Bot de Telegram
+- Clau API de MarketRouter
+
+## Instal·lació
+
+1. Clona el repositori:
+   ```
+   git clone https://github.com/yourusername/GroupLang-secretary-bot.git
+   cd GroupLang-secretary-bot
+   ```
+
+2. Instal·la Poetry si no ho has fet ja:
+   ```
+   curl -sSL https://install.python-poetry.org | python3 -
+   ```
+
+3. Instal·la les dependències utilitzant Poetry:
+   ```
+   poetry install
+   ```
+
+## Configuració
+
+1. Configura les variables d'entorn:
+   - `TELEGRAM_BOT_TOKEN`: El teu Token de Bot de Telegram
+   - `AWS_ACCESS_KEY_ID`: El teu ID de Clau d'Accés d'AWS
+   - `AWS_SECRET_ACCESS_KEY`: La teva Clau d'Accés Secreta d'AWS
+   - `MARKETROUTER_API_KEY`: La teva Clau API de MarketRouter
+
+2. Configura les credencials d'AWS:
+   - Configura el CLI d'AWS o utilitza les variables d'entorn esmentades anteriorment
+
+## Ús
+
+1. Activa l'entorn virtual de Poetry:
+   ```
+   poetry shell
+   ```
+
+2. Inicia el bot:
+   ```
+   uvicorn main:app --reload
+   ```
+
+3. A Telegram, inicia una conversa amb el bot o afegeix-lo a un grup
+
+4. Envia un missatge de veu al bot
+
+5. El bot transcriurà l'àudio, resumirà el contingut i enviarà el resultat de tornada
+
+6. Els usuaris poden donar propines utilitzant el botó en línia proporcionat amb la resposta
+
+## Afegir o Actualitzar Dependències
+
+Per afegir un nou paquet:
+```
+poetry add nom_del_paquet
+```
+
+Per actualitzar tots els paquets:
+```
+poetry update
+```
+
+Per actualitzar un paquet específic:
+```
+poetry update nom_del_paquet
+```
+
+## Referència de l'API
+
+El bot utilitza les següents APIs externes:
+
+- AWS Transcribe: Per a la transcripció d'àudio
+- API de MarketRouter: Per a resumir text i enviament de recompenses
+
+Consulta la documentació respectiva per a més detalls sobre aquestes APIs.

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,103 @@
+# GroupLang-secretary-bot
+
+GroupLang-secretary-bot es un bot de Telegram que transcribe mensajes de voz, resume el contenido y permite a los usuarios dar propinas por el servicio. Utiliza servicios de AWS para la transcripción y una API personalizada para la resumir. El bot está diseñado para ser desplegado como una función de AWS Lambda.
+
+## Tabla de Contenidos
+
+- [Características](#características)
+- [Requisitos Previos](#requisitos-previos)
+- [Instalación](#instalación)
+- [Configuración](#configuración)
+- [Uso](#uso)
+- [Despliegue](#despliegue)
+- [Referencia de API](#referencia-de-api)
+
+## Características
+
+- Transcribir mensajes de voz usando AWS Transcribe
+- Resumir texto transcrito usando una API personalizada
+- Permitir a los usuarios dar propinas por el servicio
+- Manejo seguro de claves API y tokens
+- Desplegable como una función de AWS Lambda
+
+## Requisitos Previos
+
+- Poetry para la gestión de dependencias
+- Cuenta de AWS con acceso a Transcribe
+- Token de Bot de Telegram
+- Clave API de MarketRouter
+
+## Instalación
+
+1. Clona el repositorio:
+   ```
+   git clone https://github.com/yourusername/GroupLang-secretary-bot.git
+   cd GroupLang-secretary-bot
+   ```
+
+2. Instala Poetry si no lo has hecho ya:
+   ```
+   curl -sSL https://install.python-poetry.org | python3 -
+   ```
+
+3. Instala las dependencias usando Poetry:
+   ```
+   poetry install
+   ```
+
+## Configuración
+
+1. Configura las variables de entorno:
+   - `TELEGRAM_BOT_TOKEN`: Tu Token de Bot de Telegram
+   - `AWS_ACCESS_KEY_ID`: Tu ID de Clave de Acceso de AWS
+   - `AWS_SECRET_ACCESS_KEY`: Tu Clave de Acceso Secreta de AWS
+   - `MARKETROUTER_API_KEY`: Tu Clave API de MarketRouter
+
+2. Configura las credenciales de AWS:
+   - Configura el CLI de AWS o usa las variables de entorno mencionadas arriba
+
+## Uso
+
+1. Activa el entorno virtual de Poetry:
+   ```
+   poetry shell
+   ```
+
+2. Inicia el bot:
+   ```
+   uvicorn main:app --reload
+   ```
+
+3. En Telegram, inicia una conversación con el bot o añádelo a un grupo
+
+4. Envía un mensaje de voz al bot
+
+5. El bot transcribirá el audio, resumirá el contenido y enviará el resultado de vuelta
+
+6. Los usuarios pueden dar propinas usando el botón en línea proporcionado con la respuesta
+
+## Añadir o Actualizar Dependencias
+
+Para añadir un nuevo paquete:
+```
+poetry add nombre_del_paquete
+```
+
+Para actualizar todos los paquetes:
+```
+poetry update
+```
+
+Para actualizar un paquete específico:
+```
+poetry update nombre_del_paquete
+```
+
+## Referencia de API
+
+El bot utiliza las siguientes APIs externas:
+
+- AWS Transcribe: Para la transcripción de audio
+- API de MarketRouter: Para la resumir de texto y envío de recompensas
+
+Consulta la documentación respectiva para más detalles sobre estas APIs.


### PR DESCRIPTION
## Description
This pull request addresses the issue "Documentation in Spanish and Catalan" in the `grouplang-secretary-bot` repository. The aim is to create documentation in both Spanish and Catalan using the provided files. Additionally, instructions on how to access the documentation will be added to the README.

## Changes Made
- Created documentation in Spanish and Catalan based on the provided files.
- Added instructions in the README on how to access the newly created documentation.

## Related Links
- [Repository URL](repository-url)
- [Issue Link](issue-url)

Your feedback on the changes made in this pull request is greatly appreciated. Thank you for reviewing.